### PR TITLE
Improve documentation of available development containers

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -12,17 +12,27 @@ Container contains installation of:
 
 The container does not include gammasim-tools, which should be cloned in the ./external directory (see below).
 
-## Running a container using the prepared Docker image
+There are two options on how to use this container:
 
-- To download and run a prepared container in bash:
+1. Download from [gammasim-tools container repository](https://github.com/gammasim/containers/pkgs/container/containers%2Fgammasim-tools-dev).
+2. Build a new container from the available Dockerfile.
+
+## Running a container using the prepared Docker image available from repository
+
+Packages are available from the [gammasim-tools container repository](https://github.com/gammasim/containers/pkgs/container/containers%2Fgammasim-tools-dev).
+
+To download and run a prepared container in bash:
 
 ```
-$ docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/containers/gammasim-tools-dev:v0.2.0-dev1 bash
+$ docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/containers/gammasim-tools-dev:v0.3.0-dev1 bash
 ```
-- If you don't have a prepared container, follow the instructions below.
+## Build a new container
 
-## First step: Preparation
-- Create a folder called gammasim:
+Description of build a new container using the [Dockerfile](Dockerfile) available in this directory.
+
+**Preparation:**
+
+1. Create a folder called gammasim:
 ```
 mkdir gammasim
 ```
@@ -39,14 +49,11 @@ cd gammasim-tools
 ```
 - Set up the db authentication file with the appropriated information in the gammasim-tools folder. The file should be named *dbDetails.yml* and should contain details on the connection to the DB. A template is available in the *dbDetails_template.yml* file. Ask for details of the connection to the responsible person.
 
-## Second step: Build the Docker
 - Go to the following path (gammasim/containers/dev/) and assure that there is a *Dockerfile* there:
 ```
 cd ../../
 ls
 ```
-
-## Building the Container
 
 Building expects that a tar ball of corsika/sim\_telarray (named corsika7.7\_simtelarray.tar.gz) is available in the building directory.
 Download the tar package from the MPIK website (password applies) with
@@ -55,11 +62,14 @@ Download the tar package from the MPIK website (password applies) with
 ```
 ../tools/download_simulationsoftware.sh
 ```
+
+**Building:**
+
 - In the same folder (gammasim/containers/dev/), build the docker:
 ```
 docker build -t gammasim-tools-dev .
 ```
-## Third step: Run the docker
+
 - Once it is ready (it might take some minutes) run the docker in the same folder (gammasim/containers/dev/):
 ```
 docker run --rm -it -v "$(pwd)/external:/workdir/external" gammasim-tools-dev bash
@@ -78,7 +88,3 @@ exit
 __Apple silicon users, notice you should add --platform=linux/amd64 to the run command above.__
 
 Any output will be written to the `$(pwd)/external` directory.
-
-## Docker Hub
-
-An example image is available from [Docker hub](https://hub.docker.com/repository/docker/gernotmaier/gammasim-tools-dev).

--- a/dev/README.md
+++ b/dev/README.md
@@ -17,7 +17,7 @@ There are two options on how to use this container:
 1. Download from [gammasim-tools container repository](https://github.com/gammasim/containers/pkgs/container/containers%2Fgammasim-tools-dev).
 2. Build a new container from the available Dockerfile.
 
-## Running a container using the prepared Docker image available from repository
+## Run a container using the prepared Docker image available from repository
 
 Packages are available from the [gammasim-tools container repository](https://github.com/gammasim/containers/pkgs/container/containers%2Fgammasim-tools-dev).
 
@@ -32,16 +32,13 @@ Description of build a new container using the [Dockerfile](Dockerfile) availabl
 
 **Preparation:**
 
-1. Create a folder called gammasim:
+Create a folder called gammasim and clone the container project:
 ```
 mkdir gammasim
-```
-- Go to the folder and clone the container project
-```
 cd gammasim
 git clone git@github.com:gammasim/containers.git
 ```
-- Go to the following path and clone gammasim-tools there:
+- Clone gammasim-tools into the external directory (this is where the source files of gammasim-tools will be available for development):
 ```
 cd containers/dev/external
 git clone git@github.com:gammasim/gammasim-tools.git
@@ -80,10 +77,7 @@ cd gammasim-tools
 pytest --no-cov
 ```
 - If everything works out, all the tests will pass.
-- To leave the docker just type:
-```
-exit
-```
+- To leave the docker just type: `exit`
 
 __Apple silicon users, notice you should add --platform=linux/amd64 to the run command above.__
 


### PR DESCRIPTION
Mostly to make it clearer that containers exists on this webpage and generally no building by the user is required.

@orelgueta - could you check if the section about the dbDetails.yml file is still ok (I guess it will anyway go at some point).