### PR TITLE
allow manual building of containers

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,6 +2,7 @@
 name: docker-simtools
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
Allow to build containers manually.

Need to push this to the main branch to test it (see https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow; workflow files needs to be on the default branch).