### PR TITLE
Manual workflow 

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -75,9 +75,9 @@ jobs:
         with:
           tags: |
             type=ref,event=pr
-            type=ref,event=push
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=raw,pattern={{date 'YYYYMMDD'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -77,6 +77,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=workflow_dispatch, pattern={{date 'YYYYMMDD-HHmmss'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -71,13 +71,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4.6
+        uses: docker/metadata-action@v4
         with:
           tags: |
             type=ref,event=pr
+            type=ref,event=push
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=sha,event=workflow_dispatch, pattern={{date 'YYYYMMDD-HHmmss'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -77,7 +77,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=raw,value={{date 'YYYYMMDD'}}
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -77,7 +77,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=raw,pattern={{date 'YYYYMMDD'}}
+            type=raw,value={{date 'YYYYMMDD'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -85,7 +85,11 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ github.event_name == 'pull_request' || github.event_name == 'release' }}
+          push:
+            ${{ github.event_name == 'pull_request' ||
+            github.event_name == 'release' ||
+            github.event_name == 'workflow_dispatch'
+          }}
           file: ./containers/${{ matrix.type }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
+        continue-on-error: true
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -77,7 +77,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=workflow_dispatch, pattern={{date 'YYYYMMDD-HHmmss'}}
+            type=ref,event=workflow_dispatch, pattern={{date 'YYYYMMDD-HHmmss'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -83,7 +83,6 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
-        continue-on-error: true
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -86,10 +86,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            github.event_name == 'workflow_dispatch'
-          }}
+            ${{ github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
           file: ./containers/${{ matrix.type }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -71,13 +71,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v4.6
         with:
           tags: |
             type=ref,event=pr
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=ref,event=workflow_dispatch, pattern={{date 'YYYYMMDD-HHmmss'}}
+            type=sha,event=workflow_dispatch, pattern={{date 'YYYYMMDD-HHmmss'}}
           images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
           flavor: latest=true
 


### PR DESCRIPTION
Allow to manual execute container building and push to packages.

This is an intermediate solution and solves the issue when e.g., a new feature is introduced in simtools which is required for the workflow developement (workflows use the latest container images from this repository).

Need to find a better solution in future. Unfortunately there are no cross-repository triggers for actions (e.g., a merge to main in simtools would trigger the building here).