### PR TITLE
Replace mamba by conda

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -30,8 +30,7 @@ RUN cd sim_telarray && \
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -p).sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /workdir/conda && \
     rm ~/miniconda.sh && \
-    /workdir/conda/bin/conda clean -tipy && \
-    /workdir/conda/bin/conda install -c conda-forge mamba
+    /workdir/conda/bin/conda clean -tipy
 
 RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/master/environment.yml
 
@@ -52,8 +51,8 @@ RUN apt-get update && apt-get install -y \
 
 ENV PATH /workdir/conda/bin:$PATH
 
-RUN mamba env update -n base --file environment.yml && \
-    conda remove --yes mamba && conda clean --all
+RUN conda env update -n base --file environment.yml && \
+    conda clean --all
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -32,8 +32,7 @@ RUN cd sim_telarray && \
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -p).sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /workdir/conda && \
     rm ~/miniconda.sh && \
-    /workdir/conda/bin/conda clean -tipy && \
-    /workdir/conda/bin/conda install -c conda-forge mamba
+    /workdir/conda/bin/conda clean -tipy
 
 From ubuntu:22.10
 WORKDIR /workdir
@@ -58,9 +57,8 @@ RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zi
     mv environment.yml environment.yml.tmp && \
     grep -v "name: simtools-dev" environment.yml.tmp > environment.yml 
 
-RUN conda install -c conda-forge mamba && \
-    mamba env update -n base --file simtools/environment.yml && \
-    mamba clean -tip
+RUN conda env update -n base --file simtools/environment.yml && \
+    conda clean -tip
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
use consistently conda and mamba for the image generation.

Every couple of weeks there are issues with mamba (e.g., see [this failed CI run](https://github.com/gammasim/containers/actions/runs/5530971327/jobs/10091105851#step:8:8264)). It almost looks look like mamba is not in all cases up to date?

Anyway, I suggest to simply use conda and not using more hours on this issue.