### PR TITLE
Use pyproject in prod container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
-    tar -xvzf corsika7.7_simtelarray.tar.gz && \
+    tar -xvf corsika7.7_simtelarray.tar.gz && \
     ./build_all prod5 qgs2 gsl && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -29,16 +29,10 @@ RUN cd sim_telarray && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -p).sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /workdir/conda && \
-    rm ~/miniconda.sh && \
-    /workdir/conda/bin/conda clean -tipy
-
 From ubuntu:22.10
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
-COPY --from=build_image /workdir/conda /workdir/conda
 
 RUN apt-get update && apt-get install -y \
     bzip2 \
@@ -46,10 +40,13 @@ RUN apt-get update && apt-get install -y \
     libgsl-dev \
     bc \
     unzip \
-    wget && \
+    wget \
+    python3-pip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH /workdir/conda/bin:$PATH
+RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    ln -s /usr/bin/python3 /usr/bin/python
 
 RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zip && \
     unzip main.zip && rm -f main.zip && \
@@ -57,9 +54,6 @@ RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zi
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]
-
-RUN source /root/.bashrc && \
-    conda init bash
 
 RUN cd /workdir/simtools && \
     pip install --no-cache-dir .

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y \
 ENV PATH /workdir/conda/bin:$PATH
 
 RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zip && \
-    unzip main.zip && \
+    unzip main.zip && rm -f main.zip && \
     mv simtools-main simtools
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -52,13 +52,8 @@ RUN apt-get update && apt-get install -y \
 ENV PATH /workdir/conda/bin:$PATH
 
 RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zip && \
-    unzip main.zip && mv simtools-main simtools && \
-    rm -f main.zip && cd simtools && \
-    mv environment.yml environment.yml.tmp && \
-    grep -v "name: simtools-dev" environment.yml.tmp > environment.yml 
-
-RUN conda env update -n base --file simtools/environment.yml && \
-    conda clean -tip
+    unzip main.zip && \
+    mv simtools-main simtools
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]
@@ -67,6 +62,6 @@ RUN source /root/.bashrc && \
     conda init bash
 
 RUN cd /workdir/simtools && \
-    pip install --no-cache-dir -e .
+    pip install --no-cache-dir .
 
 WORKDIR /workdir/

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
-    tar -xvzf corsika7.7_simtelarray.tar.gz && \
+    tar -xvf corsika7.7_simtelarray.tar.gz && \
     ./build_all prod5 qgs2 gsl && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
-    ln -s /usr/bin/python3 /usr/bin/python
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -f get-pip.py
 
 RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zip && \
     unzip main.zip && rm -f main.zip && \

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -35,13 +35,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
 RUN apt-get update && apt-get install -y \
+    bc \
     bzip2 \
     gfortran \
     libgsl-dev \
-    bc \
+    python3-pip \
     unzip \
-    wget \
-    python3-pip && \
+    wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \

--- a/prod/README.md
+++ b/prod/README.md
@@ -30,7 +30,7 @@ docker run --rm -it -v "$(pwd)/external:/workdir/external" \
     python /workdir/simtools/applications/print_array_elements.py
 ```
 
-## Building
+## Building (for developers)
 
 Building expects that a tar ball of corsika/sim\_telarray (corsika7.7\_simtelarray.tar.gz) is available in the building directory.
 Download the tar package from the MPIK website (password applies) with
@@ -45,4 +45,15 @@ $ ../tools/download_simulationsoftware.sh
 $ docker build -t simtools-prod .
 ```
 
-Building will take a while and the image is large (2.3 GB).
+Building will take a while and the image is large (~1.3 GB).
+
+**Running**
+
+To run the container that was just built,
+
+```
+docker run --rm -it simtools-prod bash
+```
+
+Notice that in this case we did not include the `external` directory since we did not set it up before. It can be done similarly to the `dev` container if needed though.
+

--- a/prod/README.md
+++ b/prod/README.md
@@ -53,4 +53,4 @@ $ ../tools/download_simulationsoftware.sh
 $ docker build -t simtools-prod .
 ```
 
-Building will take a while and the image is large (~1.4 GB).
+Building will take a while and the image is large (~1.4 GB). For using images build on your own, replace in all examples `ghcr.io/gammasim/simtools-prod:latest` by the local image name `simtools-prod`.

--- a/prod/README.md
+++ b/prod/README.md
@@ -9,26 +9,34 @@ Container includes installation of:
 - corsika and sim\_telarray
 - miniconda
 - packages required by simtools (from environment.yml)
-- simtools (master)
+- simtools (main branch)
 
-Images are automatically built by the [Github action workflow ../.github/workflows/build-image.yml](../.github/workflows/build-image.yml) and can be downloaded from the [gammasim package website](https://github.com/orgs/gammasim/packages).
+Images are automatically built by the [Github action workflow ../.github/workflows/build-image.yml](../.github/workflows/build-image.yml) and can be downloaded from the [gammasim package website](https://github.com/gammasim/containers/pkgs/container/simtools-prod).
 
 ## Running
 
 To run the container in bash 
-
 ```
-docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/simtools-prod:latest bash
+docker run ghcr.io/gammasim/simtools-prod:latest bash
+```
+In the container, simtools applications are installed and can be called directly (e.g., `simtools-prod simtools-print-array-elements -h`).
+
+In case file exchange with the local file system is required, use the docker syntax to mount a directory. Example:
+```
+docker run --rm -it -v "$(pwd):/workdir/external" ghcr.io/gammasim/simtools-prod:latest bash
 ```
 
-In the container, find the simtools directory in `/workdir/simtools/`.
-
-To run an application inside the container, e.g.:
+The following examples runs an application inside the container and write the output into a directory of the local files system, 
 ```
-docker run --rm -it -v "$(pwd)/external:/workdir/external" \
+docker run --rm -it -v "$(pwd):/workdir/external" \
     ghcr.io/gammasim/simtools-prod:latest \
-    python /workdir/simtools/applications/print_array_elements.py
+    simtools-print-array-elements \
+    --array_element_list ./simtools/tests/resources/telescope_positions-North-utm.ecsv \
+    --export corsika --use_corsika_telescope_height \
+    --output_path /workdir/external/
 ```
+
+Output files can be found `./simtools-output/`.
 
 ## Building (for developers)
 
@@ -45,15 +53,4 @@ $ ../tools/download_simulationsoftware.sh
 $ docker build -t simtools-prod .
 ```
 
-Building will take a while and the image is large (~1.3 GB).
-
-**Running**
-
-To run the container that was just built,
-
-```
-docker run --rm -it simtools-prod bash
-```
-
-Notice that in this case we did not include the `external` directory since we did not set it up before. It can be done similarly to the `dev` container if needed though.
-
+Building will take a while and the image is large (~1.4 GB).

--- a/prod/README.md
+++ b/prod/README.md
@@ -26,7 +26,7 @@ In case file exchange with the local file system is required, use the docker syn
 docker run --rm -it -v "$(pwd):/workdir/external" ghcr.io/gammasim/simtools-prod:latest bash
 ```
 
-The following examples runs an application inside the container and write the output into a directory of the local files system, 
+The following example runs an application inside the container and write the output into a directory of the local files system, 
 ```
 docker run --rm -it -v "$(pwd):/workdir/external" \
     ghcr.io/gammasim/simtools-prod:latest \

--- a/simtelarray/Dockerfile
+++ b/simtelarray/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
-    tar -xvzf corsika7.7_simtelarray.tar.gz && \
+    tar -xvf corsika7.7_simtelarray.tar.gz && \
     ./build_all prod5 qgs2 gsl && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..


### PR DESCRIPTION
Please review after #40 and #41.

No need to use is conda env create in the production container - we can do now 'pip install'.

Note that conda is still needed for a consistent pip / python installation (if you have a lot of time...search the web and try do to it without conda...).

