### PR TITLE
Dev Docker with pip

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,9 +13,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libgsl-dev \
     make \
-    unzip \
-    vim \
-    wget && \
+    unzip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # corsika and sim_telarray
@@ -27,37 +25,34 @@ RUN cd sim_telarray && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -p).sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /workdir/conda && \
-    rm ~/miniconda.sh && \
-    /workdir/conda/bin/conda clean -tipy
-
-RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/environment.yml
-
 From ubuntu:22.10
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
-COPY --from=build_image /workdir/conda /workdir/conda
-COPY --from=build_image /workdir/environment.yml /workdir/environment.yml
 
 RUN apt-get update && apt-get install -y \
+    bc \
     bzip2 \
     gfortran \
     libgsl-dev \
-    bc \
-    unzip && \
+    python3-pip \
+    unzip \
+    wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH /workdir/conda/bin:$PATH
+RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    ln -s /usr/bin/python3 /usr/bin/python
 
-RUN conda env update -n base --file environment.yml && \
-    conda clean --all
+RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/setup.py && \
+    wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml
+
+RUN cd /workdir/ && \
+    pip install '.[tests,dev,doc]'
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]
 
-RUN source /root/.bashrc && \
-    conda init bash
+RUN source /root/.bashrc
 
 WORKDIR /workdir/external

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -32,7 +32,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(u
     rm ~/miniconda.sh && \
     /workdir/conda/bin/conda clean -tipy
 
-RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/master/environment.yml
+RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/environment.yml
 
 From ubuntu:22.10
 WORKDIR /workdir

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
-    tar -xvzf corsika7.7_simtelarray.tar.gz && \
+    tar -xvf corsika7.7_simtelarray.tar.gz && \
     ./build_all prod5 qgs2 gsl && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..
@@ -53,6 +53,5 @@ RUN cd /workdir/ && \
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]
 
-RUN source /root/.bashrc
 
 WORKDIR /workdir/external

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get update && apt-get install -y \
     gfortran \
     libgsl-dev \
     python3-pip \
-    unzip \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -76,11 +76,10 @@ docker build -t simtools-dev .
 
 - Once it is ready (it might take some minutes) run the docker in the same folder (gammasim/containers/dev/):
 ```
-docker run --rm -it -v "$(pwd)/external:/workdir/external" simtools-dev bash
+docker run --rm -it -v "$(pwd)/external:/workdir/external" simtools-dev bash -c "$(cat ./entrypoint.sh) && bash"
 ```
-- Now you are inside the docker. To test the setup, go the simtools folder and run a pytest:
+- Now you are inside the docker. To test the setup, run pytest after entering the docker image:
 ```
-cd simtools
 pytest --no-cov
 ```
 - If everything works out, all the tests will pass.


### PR DESCRIPTION
Two changes:

- use pip instead conda in container
- update  the readme adding the executation of `entrypoint.sh` to the testing step.

Closely related to #42 (tried to sync as much as possible)