### PR TITLE
Fix prod and dev container after recent updates to pyproject.toml

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -43,11 +43,12 @@ RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     ln -s /usr/bin/python3 /usr/bin/python
 
-RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/setup.py && \
-    wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml
+RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
+    pip install toml-to-requirements && \
+    toml-to-req --toml-file pyproject.toml --include-optional
 
 RUN cd /workdir/ && \
-    pip install '.[tests,dev,doc]'
+    pip install -r requirements.txt
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -34,14 +34,17 @@ RUN apt-get update && apt-get install -y \
     bc \
     bzip2 \
     gfortran \
+    git \
     libgsl-dev \
     python3-pip \
+    unzip \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
-    ln -s /usr/bin/python3 /usr/bin/python
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -f get-pip.py
 
 RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
     pip install toml-to-requirements && \
@@ -52,6 +55,5 @@ RUN cd /workdir/ && \
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]
-
 
 WORKDIR /workdir/external

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     bc \
     bzip2 \
     gfortran \
+    git \
     libgsl-dev \
     python3-pip \
     unzip \
@@ -49,9 +50,7 @@ RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -f get-pip.py
 
-RUN wget --quiet https://github.com/gammasim/simtools/archive/refs/heads/main.zip && \
-    unzip main.zip && rm -f main.zip && \
-    mv simtools-main simtools
+RUN git clone https://github.com/gammasim/simtools.git
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 SHELL ["/bin/bash", "-c"]

--- a/simtelarray/Dockerfile
+++ b/simtelarray/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     bzip2 \
     csh \
     gfortran \
-    gcc \ 
+    gcc \
     g++ \
     git \
     libgsl-dev \


### PR DESCRIPTION
The recent updates to pyproject.toml unfortunately broke both dev and prod containers:

Prod:

The setting of the simtools version using  setuptools-scm  requires a full git clone (and not a simple wget of the zip file from github).

This requires also the installation of git which increase the size of the container by a very small amount.

Dev:

`pip install '.[tests,dev,doc]'` is not working anymore without the simtools code available. I see three options to solve this and I've decided the last one is the simplest:
- heavily use sed and grep to modify the pyproject.toml file (but any change to the file would require to adapt those sed/grep commands)
- move back to use mamba or conda 
- use the tiny ptoml-to-requirements](https://pypi.org/project/toml-to-requirements/) package to export the dependencies to a requirements.txt file and use this in `pip install -r requirements.txt`.


