### PR TITLE
Remove weekly image generation

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,8 +10,6 @@ on:
     branches: ["main"]
   release:
     types: [published]
-  schedule:
-    - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
We had a weekly image generation workflow - mostly as we had no connection between the simtools repository and this one (allowed therefore to have always to have an up-to-date image).

As we move the docker files into simtools, I remove this to avoid noise.